### PR TITLE
Redirect docs to docs/ to fix paths to assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The default UI is a mountable Sinatra application. It's perfectly fine to mount
 it within a Rails application, namely `config/routes.rb`.
 
 ```ruby
+match 'docs', to: redirect { |_, r| "#{r.path}/" }, via: :all, constraints: lambda { |r| !r.original_fullpath.end_with?('/') }
 mount CabbageDoc::Web, at: '/docs'
 ```
 


### PR DESCRIPTION
CabbageDoc web module uses relative paths so trailing slashes are very important.

At /docs, stylesheet points to /css/application.css
At /docs/, stylsheet points to /docs/css/application.css

Since it's a mountable Rack application, the latter is expected and needs to be enforced all the time.

tl;dr This won't happen ever again:

![image](https://cloud.githubusercontent.com/assets/611746/15914799/65e643de-2da9-11e6-9122-f938d8eb9a57.png)
